### PR TITLE
Change pod documentation on cheatsheet and in docs

### DIFF
--- a/tests/dummy/app/templates/docs/cheatsheet.md
+++ b/tests/dummy/app/templates/docs/cheatsheet.md
@@ -134,8 +134,8 @@ ember generate component --pod my-component
 
 ```text
 components/
-    pod-button-name/
-        components.hbs
+    my-component/
+        component.js
         template.hbs
 ```
 

--- a/tests/dummy/app/templates/docs/pods.md
+++ b/tests/dummy/app/templates/docs/pods.md
@@ -5,17 +5,17 @@ Pods are an alternate file layout option in Ember. They were originally released
 To create a component using pods, do something like: 
 
 ```sh
-ember generate component --pod pod-button-name
+ember generate component --pod my-component
 ```
 
-This creates a directory at `components/pod-button-name` that contains a `component.js` and `template.hbs` file.
+This creates a directory at `components/my-component` that contains a `component.js` and `template.hbs` file.
 
 ## Result
 
 ```text
 components/
-    pod-button-name/
-        components.hbs
+    my-component/
+        component.js
         template.hbs
 ```
 


### PR DESCRIPTION
The pod component is called `my-component` on invocation, but the
resulting files tree calls it `pod-button-name`. Similarly,
`component.js` is called `components.hbs`. This happens in both the pods
documentation and the cheat sheet.